### PR TITLE
Fix KL divergence estimator

### DIFF
--- a/rocket_learn/ppo.py
+++ b/rocket_learn/ppo.py
@@ -352,7 +352,8 @@ class PPO:
 
                 loss.backward()
 
-                total_kl_div += th.mean((th.exp(ratio.detach().cpu()) - 1) - ratio.detach().cpu())
+                # Unbiased low variance KL div estimator from http://joschu.net/blog/kl-approx.html
+                total_kl_div += th.mean((ratio - 1) - (log_prob - old_log_prob)).item()
                 tot_loss += loss.item()
                 tot_policy_loss += policy_loss.item()
                 tot_entropy_loss += entropy_loss.item()


### PR DESCRIPTION
The previous estimator was simply incorrect, I suspect this is what was causing the inf spikes in KL div.

I tested this estimator in my own framework and it works as expected. I haven't run this code in rocket learn, so I recommend doing a sanity check before merging/releasing.

Source for the correct equation: http://joschu.net/blog/kl-approx.html

Previous eq:
```
KL = (e^ratio - 1) - ratio
```
New eq:
```
KL = (ratio - 1) - ln(ratio) = (ratio - 1) - ln(new_probs / old_probs) = (ratio - 1) - (ln(new_probs) - ln(old_probs))