### PR TITLE
fix divide by zero for plot rating mid when only one gamemode

### DIFF
--- a/rocket_learn/rollout_generator/redis/redis_rollout_generator.py
+++ b/rocket_learn/rollout_generator/redis/redis_rollout_generator.py
@@ -202,6 +202,8 @@ class RedisRolloutGenerator(BaseRolloutGenerator):
                             means[mode][v] = (mean[0] + r.mu, mean[1] + r.sigma ** 2)
                             # *Smoothly* transition from red, to green, to blue depending on gamemode
                     mid = (len(self.gamemodes) - 1) / 2
+                    if mid == 0:
+                        mid = 0.5
                     if i < mid:
                         r = 1 - i / mid
                         g = i / mid


### PR DESCRIPTION
if only one gamemode is sent, it will divide by 0. Changed it so if only one gamemode it seems to pick two different shades of red, which is fine enough. At least it doesn't crash.