### PR TITLE
Improve gamemode weighting

### DIFF
--- a/rocket_learn/rollout_generator/redis/redis_rollout_worker.py
+++ b/rocket_learn/rollout_generator/redis/redis_rollout_worker.py
@@ -84,7 +84,7 @@ class RedisRolloutWorker:
         if self.gamemode_weights is None:
             self.gamemode_weights = {'1v1': 0.333334, '2v2': 0.333333, '3v3': 0.333333}
         assert sum(self.gamemode_weights.values()) == 1, "gamemode_weights must sum to 1"
-        self.previous_weights = self.gamemode_weights
+        self.target_weights = self.gamemode_weights
         self.local_cache_name = local_cache_name
 
         self.uuid = str(uuid4())
@@ -220,8 +220,8 @@ class RedisRolloutWorker:
             total = sum(mode_exp.values()) + 1e-8
             mode_exp = {k: mode_exp[k] / total for k in mode_exp.keys()}
             # find exp which is farthest below desired exp
-            diff = {k: self.gamemode_weights[k] - mode_exp[k] for k in mode_exp.keys()}
-            self.gamemode_weights = {k: self.gamemode_weights[k] + diff[k] / 3 for k in self.gamemode_weights.keys()}
+            diff = {k: self.target_weights[k] - mode_exp[k] for k in mode_exp.keys()}
+            self.gamemode_weights = {k: max(self.gamemode_weights[k] + diff[k] / 3, 0) for k in self.gamemode_weights.keys()}
             new_sum = sum(self.gamemode_weights.values())
             self.gamemode_weights = {k: self.gamemode_weights[k] / new_sum for k in self.gamemode_weights.keys()}
             self.updated_weights = True

--- a/rocket_learn/rollout_generator/redis/redis_rollout_worker.py
+++ b/rocket_learn/rollout_generator/redis/redis_rollout_worker.py
@@ -2,6 +2,7 @@ import functools
 import itertools
 import os
 import time
+import copy
 from threading import Thread
 from uuid import uuid4
 
@@ -80,11 +81,17 @@ class RedisRolloutWorker:
         self.send_obs = send_obs
         self.dynamic_gm = dynamic_gm
         self.gamemode_weights = gamemode_weights
-        self.updated_weights = True
         if self.gamemode_weights is None:
-            self.gamemode_weights = {'1v1': 0.333334, '2v2': 0.333333, '3v3': 0.333333}
+            self.gamemode_weights = {'1v1': 1/3, '2v2': 1/3, '3v3': 1/3}
         assert sum(self.gamemode_weights.values()) == 1, "gamemode_weights must sum to 1"
-        self.target_weights = self.gamemode_weights
+        self.target_weights = copy.copy(self.gamemode_weights)
+        # change weights from percentage of experience desired to percentage of gamemodes necessary (approx)
+        for k in self.gamemode_weights.keys():
+            b, o = k.split("v")
+            self.gamemode_weights[k] /= int(b)
+        weights_sum = sum(self.gamemode_weights.values())
+        self.gamemode_weights = {k: self.gamemode_weights[k] / weights_sum for k in self.gamemode_weights.keys()}
+        self.experience = {'1v1': 0, '2v2': 0, '3v3': 0}
         self.local_cache_name = local_cache_name
 
         self.uuid = str(uuid4())
@@ -214,18 +221,16 @@ class RedisRolloutWorker:
 
     def select_gamemode(self):
 
-        if not self.updated_weights:
-            # update weights once per worker per new model
-            mode_exp = {m.decode("utf-8"): int(v) for m, v in self.redis.hgetall(EXPERIENCE_PER_MODE).items()}
-            total = sum(mode_exp.values()) + 1e-8
-            mode_exp = {k: mode_exp[k] / total for k in mode_exp.keys()}
-            # find exp which is farthest below desired exp
-            diff = {k: self.target_weights[k] - mode_exp[k] for k in mode_exp.keys()}
-            self.gamemode_weights = {k: max(self.gamemode_weights[k] + diff[k] / 3, 0) for k in self.gamemode_weights.keys()}
-            new_sum = sum(self.gamemode_weights.values())
-            self.gamemode_weights = {k: self.gamemode_weights[k] / new_sum for k in self.gamemode_weights.keys()}
-            self.updated_weights = True
-            print(f"New gamemode weights are {self.gamemode_weights}")
+        total = sum(self.experience.values()) + 1e-8
+        mode_exp = {k: self.experience[k] / total for k in self.experience.keys()}
+        diff = {k: self.target_weights[k] - mode_exp[k] for k in mode_exp.keys()}
+        # change diff from experience weights to gamemode weights
+        for k in diff.keys():
+            b, o = k.split("v")
+            diff[k] *= int(b)
+        self.gamemode_weights = {k: max(self.gamemode_weights[k] + diff[k], 0) for k in self.gamemode_weights.keys()}
+        new_sum = sum(self.gamemode_weights.values())
+        self.gamemode_weights = {k: self.gamemode_weights[k] / new_sum for k in self.gamemode_weights.keys()}
         mode = np.random.choice(list(self.gamemode_weights.keys()), p=list(self.gamemode_weights.values()))
         b, o = mode.split("v")
         return int(b), int(o)
@@ -249,7 +254,6 @@ class RedisRolloutWorker:
 
             # Only try to download latest version when new
             if latest_version != available_version:
-                self.updated_weights = False
                 model_bytes = self.redis.get(MODEL_LATEST)
                 if model_bytes is None:
                     time.sleep(1)
@@ -319,7 +323,9 @@ class RedisRolloutWorker:
                 state = rollouts[0].infos[-2]["state"]
                 goal_speed = np.linalg.norm(state.ball.linear_velocity) * 0.036  # kph
                 str_result = ('+' if result > 0 else "") + str(result)
-                self.total_steps_generated += len(rollouts[0].observations) * len(rollouts)
+                episode_exp = len(rollouts[0].observations) * len(rollouts)
+                self.total_steps_generated += episode_exp
+                self.experience[f"{blue}v{orange}"] += episode_exp
                 post_stats = f"Rollout finished after {len(rollouts[0].observations)} steps ({self.total_steps_generated} total steps), result was {str_result}"
                 if result != 0:
                     post_stats += f", goal speed: {goal_speed:.2f} kph"


### PR DESCRIPTION
This changes the gamemode weighting to be faster (no redis calls) and more stable so that it doesn't swing around so much. Each training step should have a very, very similar weight of gamemodes, that's very close to the desired weight, even if the training steps are very short (I've tested with 100k steps).